### PR TITLE
added support for guids and nullable value types for open api extensions

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/EnumExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/EnumExtensions.cs
@@ -29,13 +29,20 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
             return name;
         }
 
+        public static bool IsSimpleType(this Type type)
+        {
+            var @enum = Type.GetTypeCode(type);
+            return @enum != TypeCode.Object;
+        }
+
         /// <summary>
         /// Converts the <see cref="TypeCode"/> value into data type specified in Open API spec.
         /// </summary>
-        /// <param name="enum"><see cref="TypeCode"/> value.</param>
+        /// <param name="type"><see cref="Type"/> value.</param>
         /// <returns>Data type specified in Open API spec.</returns>
-        public static string ToDataType(this TypeCode @enum)
+        public static string ToDataType(this Type type)
         {
+            var @enum = Type.GetTypeCode(type);
             switch (@enum)
             {
                 case TypeCode.Int16:
@@ -56,7 +63,14 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                     return "string";
 
                 case TypeCode.Object:
-                    return "object";
+                    if (type == typeof(Guid))
+                    {
+                        return "string";
+                    }
+                    else
+                    {
+                        return "object";
+                    }
 
                 case TypeCode.Empty:
                 case TypeCode.DBNull:
@@ -74,10 +88,11 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
         /// <summary>
         /// Converts the <see cref="TypeCode"/> value into data format specified in Open API spec.
         /// </summary>
-        /// <param name="enum"><see cref="TypeCode"/> value.</param>
+        /// <param name="type"><see cref="Type"/> value.</param>
         /// <returns>Data format specified in Open API spec.</returns>
-        public static string ToDataFormat(this TypeCode @enum)
+        public static string ToDataFormat(this Type type)
         {
+            var @enum = Type.GetTypeCode(type);
             switch (@enum)
             {
                 case TypeCode.Int16:
@@ -105,8 +120,16 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                 case TypeCode.UInt64:
                 case TypeCode.Boolean:
                 case TypeCode.String:
-                case TypeCode.Object:
                     return null;
+                case TypeCode.Object:
+                    if (type == typeof(Guid))
+                    {
+                        return "uuid";
+                    }
+                    else
+                    {
+                        return null;
+                    }
 
                 case TypeCode.Empty:
                 case TypeCode.DBNull:

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiParameterAttributeExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiParameterAttributeExtensions.cs
@@ -22,11 +22,10 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
         {
             attribute.ThrowIfNullOrDefault();
 
-            var typeCode = Type.GetTypeCode(attribute.Type);
             var schema = new OpenApiSchema()
                              {
-                                 Type = typeCode.ToDataType(),
-                                 Format = typeCode.ToDataFormat()
+                                 Type = attribute.Type.ToDataType(),
+                                 Format = attribute.Type.ToDataFormat()
                              };
             var parameter = new OpenApiParameter()
                                 {

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiParameterExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiParameterExtensions.cs
@@ -52,11 +52,10 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
             type.ThrowIfNullOrDefault();
             name.ThrowIfNullOrWhiteSpace();
 
-            var typeCode = Type.GetTypeCode(type);
             var schema = new OpenApiSchema()
                              {
-                                 Type = typeCode.ToDataType(),
-                                 Format = typeCode.ToDataFormat()
+                                 Type = type.ToDataType(),
+                                 Format = type.ToDataFormat()
                              };
             var parameter = new OpenApiParameter()
                                 {

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
@@ -29,12 +29,20 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
         public static OpenApiSchema ToOpenApiSchema(this Type type, OpenApiSchemaVisibilityAttribute attribute = null)
         {
             type.ThrowIfNullOrDefault();
+            OpenApiSchema schema = null;
 
-            var typeCode = Type.GetTypeCode(type);
-            var schema = new OpenApiSchema()
+            var unwrappedValueType = Nullable.GetUnderlyingType(type);
+            if (unwrappedValueType != null)
+            {
+                schema = unwrappedValueType.ToOpenApiSchema();
+                schema.Nullable = true;
+                return schema;
+            }
+
+            schema = new OpenApiSchema()
                              {
-                                 Type = typeCode.ToDataType(),
-                                 Format = typeCode.ToDataFormat()
+                                 Type = type.ToDataType(),
+                                 Format = type.ToDataFormat()
                              };
             if (attribute != null)
             {
@@ -43,7 +51,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                 schema.Extensions.Add("x-ms-visibility", visibility);
             }
 
-            if (typeCode != TypeCode.Object)
+            if (type.IsSimpleType())
             {
                 return schema;
             }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/EnumExtensionsTests.cs
@@ -30,37 +30,34 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_TypeCode_ToDataType_Should_Throw_Exception()
         {
-            var typeCode = TypeCode.Empty;
-
-            Action action = () => EnumExtensions.ToDataType(typeCode);
+            Action action = () => EnumExtensions.ToDataType(null);
             action.Should().Throw<InvalidOperationException>();
         }
 
         [TestMethod]
         public void Given_TypeCode_ToDataType_Should_Return_Value()
         {
-            var typeCode = TypeCode.Int16;
-            var dataType = EnumExtensions.ToDataType(typeCode);
+            var dataType = EnumExtensions.ToDataType(typeof(Int16));
 
             dataType.Should().BeEquivalentTo("integer");
 
-            typeCode = TypeCode.Single;
-            dataType = EnumExtensions.ToDataType(typeCode);
+            dataType = EnumExtensions.ToDataType(typeof(Single));
 
             dataType.Should().BeEquivalentTo("number");
 
-            typeCode = TypeCode.Boolean;
-            dataType = EnumExtensions.ToDataType(typeCode);
+            dataType = EnumExtensions.ToDataType(typeof(Boolean));
 
             dataType.Should().BeEquivalentTo("boolean");
 
-            typeCode = TypeCode.DateTime;
-            dataType = EnumExtensions.ToDataType(typeCode);
+            dataType = EnumExtensions.ToDataType(typeof(DateTime));
 
             dataType.Should().BeEquivalentTo("string");
 
-            typeCode = TypeCode.Object;
-            dataType = EnumExtensions.ToDataType(typeCode);
+            dataType = EnumExtensions.ToDataType(typeof(Guid));
+
+            dataType.Should().BeEquivalentTo("string");
+
+            dataType = EnumExtensions.ToDataType(typeof(object));
 
             dataType.Should().BeEquivalentTo("object");
         }
@@ -68,42 +65,38 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_TypeCode_ToDataFormat_Should_Throw_Exception()
         {
-            var typeCode = TypeCode.Empty;
-
-            Action action = () => EnumExtensions.ToDataFormat(typeCode);
+            Action action = () => EnumExtensions.ToDataFormat(null);
             action.Should().Throw<InvalidOperationException>();
         }
 
         [TestMethod]
         public void Given_TypeCode_ToDataFormat_Should_Return_Value()
         {
-            var typeCode = TypeCode.Int16;
-            var dataType = EnumExtensions.ToDataFormat(typeCode);
+            var dataType = EnumExtensions.ToDataFormat(typeof(Int16));
 
             dataType.Should().BeEquivalentTo("int32");
 
-            typeCode = TypeCode.Int64;
-            dataType = EnumExtensions.ToDataFormat(typeCode);
+            dataType = EnumExtensions.ToDataFormat(typeof(Int64));
 
             dataType.Should().BeEquivalentTo("int64");
 
-            typeCode = TypeCode.Single;
-            dataType = EnumExtensions.ToDataFormat(typeCode);
+            dataType = EnumExtensions.ToDataFormat(typeof(Single));
 
             dataType.Should().BeEquivalentTo("float");
 
-            typeCode = TypeCode.Double;
-            dataType = EnumExtensions.ToDataFormat(typeCode);
+            dataType = EnumExtensions.ToDataFormat(typeof(Double));
 
             dataType.Should().BeEquivalentTo("double");
 
-            typeCode = TypeCode.DateTime;
-            dataType = EnumExtensions.ToDataFormat(typeCode);
+            dataType = EnumExtensions.ToDataFormat(typeof(DateTime));
 
             dataType.Should().BeEquivalentTo("date-time");
 
-            typeCode = TypeCode.Object;
-            dataType = EnumExtensions.ToDataFormat(typeCode);
+            dataType = EnumExtensions.ToDataFormat(typeof(Guid));
+
+            dataType.Should().BeEquivalentTo("uuid");
+
+            dataType = EnumExtensions.ToDataFormat(typeof(object));
 
             dataType.Should().BeNull();
         }


### PR DESCRIPTION
Hello! I've made some changes to support guids and handle nullable value types (both types werent handled at all before). Also, I've rewritten the EnumExtensions.cs class a little, for the following reason: we shouldn't rely on exposing the TypeCode to the client code that calls the extension methods, if you ask me; maybe you'll change the way you transform the CLR types into OpenApi types, and by hiding the TypeCode dependency, you can switch it with something else much easier later. 

Thanks for your input in advance!