### PR TITLE
add missing dependency (FunctionAppCommon.Functions) to FunctionAppV2.Tests

### DIFF
--- a/test/Aliencube.AzureFunctions.FunctionAppV2.Tests/Aliencube.AzureFunctions.FunctionAppV2.Tests.csproj
+++ b/test/Aliencube.AzureFunctions.FunctionAppV2.Tests/Aliencube.AzureFunctions.FunctionAppV2.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aliencube.AzureFunctions.FunctionAppCommon\Aliencube.AzureFunctions.FunctionAppCommon.csproj" />
     <ProjectReference Include="..\..\src\Aliencube.AzureFunctions.FunctionAppV2\Aliencube.AzureFunctions.FunctionAppV2.csproj" />
     <ProjectReference Include="..\Aliencube.AzureFunctions.Tests.Fakes\Aliencube.AzureFunctions.Tests.Fakes.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The test project didn't build because of a missing reference to FunctionAppCommon.