### PR TITLE
DocumentHelper constructor with mandatory argument

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -40,7 +40,7 @@ public static async Task<IActionResult> RenderSwaggerDocument(
     ILogger log)
 {
     var settings = new AppSettings();
-    var helper = new DocumentHelper();
+    var helper = new DocumentHelper(new RouteConstraintFilter());
     var document = new Document(helper);
     var result = await document.InitialiseDocument()
                                .AddMetadata(settings.OpenApiInfo)


### PR DESCRIPTION
The code didn't compile because (as of version 1.5.1) the `DocumentHelper` class constructor has a mandatory argument. Using an initial `new RouteConstraintFilter()` might not be the most demonstrative example but at least it compiles (and seems to work for me).