### PR TITLE
Add OpenAPISubtypes to Models list

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -164,6 +164,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
             var responses = elements.SelectMany(p => p.GetCustomAttributes<OpenApiResponseBodyAttribute>(inherit: false))
                                     .Select(p => p.BodyType);
             var types = requests.Union(responses)
+                                .Select(p => p.IsOpenApiArray() ? p.GetOpenApiSubType() : p )
                                 .Distinct()
                                 .Where(p => p != typeof(JObject))
                                 .Where(p => p != typeof(JToken))

--- a/src/Aliencube.AzureFunctions.FunctionAppCommon/Models/SampleItemModel.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppCommon/Models/SampleItemModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Aliencube.AzureFunctions.FunctionAppCommon.Models
+{
+    /// <summary>
+    /// Model to be used as generic type of Lists 
+    /// </summary>
+    public class SampleItemModel
+    {
+        public String FirstName { get; set; }
+        public String LastName { get; set; }
+    }
+}

--- a/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
@@ -43,7 +43,7 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Summary = "The name query key", Visibility = OpenApiVisibilityType.Advanced)]
         [OpenApiParameter(name: "limit", In = ParameterLocation.Query, Required = false, Type = typeof(int), Description = "The number of samples to return")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(SampleResponseModel), Summary = "Sample response")]
-        [OpenApiResponseBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(List<SampleResponseModel>), Summary = "Sample response of a List")]
+        [OpenApiResponseBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(List<SampleItemModel>), Summary = "Sample response of a List")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.Accepted, contentType: "application/json", bodyType: typeof(IList<SampleResponseModel>), Summary = "Sample response of a IList")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.NonAuthoritativeInformation, contentType: "application/json", bodyType: typeof(SampleResponseModel[]), Summary = "Sample response of a Array")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json", bodyType: typeof(Dictionary<string, SampleResponseModel>), Summary = "Sample response of a Dictionary")]


### PR DESCRIPTION
fix for #40

We missed including the SubType in the Model list, since the SampleModel was already a top level response.  I added a second model type to ensure in testing we can see generic types included.