### PR TITLE
Load properties from Interface base classes

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -124,7 +125,11 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                 return schema;
             }
 
-            var properties = type.GetProperties().Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>());
+            var allProperties = !type.IsInterface
+                ? type.GetProperties()
+                : new Type[] { type }.Concat(type.GetInterfaces()).SelectMany(i => i.GetProperties());
+            var properties = allProperties.Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>());
+
             foreach (var property in properties)
             {
                 var visiblity = property.GetCustomAttribute<OpenApiSchemaVisibilityAttribute>(inherit: false);

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -187,5 +187,16 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
             result.Type.Should().NotBe("array");
             result.Items.Should().BeNull();
         }
+
+        [TestMethod]
+        public void Given_Interface_With_Inheritance_Should_Contain_All_Properties()
+        {
+            var interfaceType = typeof(IFakeInheritedInterface);
+            var strategy = new CamelCaseNamingStrategy();
+
+            var result = interfaceType.ToOpenApiSchema(strategy);
+
+            result.Properties.Count.Should().Be(4);
+        }
     }
 }

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/IFakeBaseInterface.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/IFakeBaseInterface.cs
@@ -1,0 +1,15 @@
+﻿namespace Aliencube.AzureFunctions.Tests.Fakes
+{
+    public interface IFakeBaseInterface
+    {
+        string Name { get; set; }
+        string City { get; set; }
+
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        /// <param name="input">Input value.</param>
+        /// <returns>Output value.</returns>
+        bool DoSomething(bool input);
+    }
+}

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/IFakeInheritedInterface.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/IFakeInheritedInterface.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Aliencube.AzureFunctions.Tests.Fakes
+{
+    public interface IFakeInheritedInterface : IFakeBaseInterface
+    {
+        DateTime Birthdate { get; set; }
+        double Age { get; set; }
+    }
+}


### PR DESCRIPTION
Properties from inherited interfaces were not being loaded as properties for the base interface in the "definitions" section of the generated json. I added a couple of lines of code to include those properties.