### PR TITLE
Add Support for Generic Types having different subtypes

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -172,7 +172,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
                                 .Where(p => p != typeof(JToken))
                                 .Where(p => !typeof(Array).IsAssignableFrom(p))
                                 ;
-            var schemas = types.ToDictionary(p => p.IsGenericType ? p.GetOpenApiGenericRootName() : p.Name,
+            var schemas = types.ToDictionary(p => p.IsGenericType ? p.GetOpenApiFullName() : p.Name,
                                              p => p.ToOpenApiSchema(namingStrategy)); // schemaGenerator.Generate(p)
 
             return schemas;

--- a/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
@@ -53,6 +53,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
         [OpenApiResponseBody(statusCode: HttpStatusCode.InternalServerError, contentType: "application/json", bodyType: typeof(List<string>), Summary = "Sample response of a List")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.NotImplemented, contentType: "application/json", bodyType: typeof(Dictionary<string, int>), Summary = "Sample response of a Dictionary")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.BadGateway, contentType: "application/json", bodyType: typeof(SampleGenericResponseModel<SampleResponseModel>), Summary = "Sample response of a Generic")]
+        [OpenApiResponseBody(statusCode: HttpStatusCode.Ambiguous, contentType: "application/json", bodyType: typeof(SampleGenericResponseModel<SampleItemModel>), Summary = "Second sample response of a Generic with other subtype")]
+
         public static async Task<IActionResult> GetSample(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "samples/{id:int}/categories/{category:regex(^[a-z]{{3,}}$)}")] HttpRequest req,
             int id,


### PR DESCRIPTION
Allows to have multiple request/response bodies with the same generic type using different subtypes due to recursive extraction of the key for the hash map.