### PR TITLE
Fix for infinite recurssion. Hardcoded to depth of 8 levels of model.

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -173,7 +173,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
                                 .Where(p => !typeof(Array).IsAssignableFrom(p))
                                 ;
             var schemas = types.ToDictionary(p => p.IsGenericType ? p.GetOpenApiGenericRootName() : p.Name,
-                                             p => p.ToOpenApiSchema(namingStrategy)); // schemaGenerator.Generate(p)
+                                             p => p.ToOpenApiSchema(namingStrategy,0)); // schemaGenerator.Generate(p)
 
             return schemas;
         }

--- a/src/Aliencube.AzureFunctions.FunctionAppCommon/Models/SampleRequestModel.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppCommon/Models/SampleRequestModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Aliencube.AzureFunctions.FunctionAppCommon.Models
+﻿using System.Collections.Generic;
+
+namespace Aliencube.AzureFunctions.FunctionAppCommon.Models
 {
     /// <summary>
     /// This represents the model entity for sample request.
@@ -9,5 +11,7 @@
         /// Gets or sets the Id.
         /// </summary>
         public string Id { get; set; }
+
+        public List<SampleRequestModel> Children { get; set; }
     }
 }

--- a/src/Aliencube.AzureFunctions.FunctionAppV1/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV1/SampleHttpTrigger.cs
@@ -70,5 +70,7 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
 
             return result;
         }
+
+
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_Type_Null_It_Should_Throw_Exception()
         {
-            Action action = () => OpenApiSchemaExtensions.ToOpenApiSchema(null, null, null);
+            Action action = () => OpenApiSchemaExtensions.ToOpenApiSchema(null, null, attribute:null);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -82,7 +82,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
             var visibilityType = OpenApiVisibilityType.Important;
             var visibility = new OpenApiSchemaVisibilityAttribute(visibilityType);
 
-            var schema = OpenApiSchemaExtensions.ToOpenApiSchema(type, strategy, visibility);
+            var schema = OpenApiSchemaExtensions.ToOpenApiSchema(type, strategy, attribute: visibility);
 
             schema.Extensions.ContainsKey("x-ms-visibility").Should().BeTrue();
             schema.Extensions["x-ms-visibility"].Should().BeEquivalentTo(new OpenApiString(visibilityType.ToDisplayName()));


### PR DESCRIPTION
When a model includes a prop that is either itself of includes itself, the system will continue to tree walk forever, leaving us with a stack overflow.

This is obviously a common pattern yet no clear way to describe this. I have created a simple workaround out of necessity that limits models to tree walk to 8 levels deep.

Would prefer that this was configured or smarter (for instance, it can only include ITSELF 8 times)

The perfect solution would be to do the tree walking to find all models and adding them to a flat list. Any models not already in the list are added, those who are already in the list are stepped over. This means recursion doesn't happen at all. I believe this is how swashbuckler handles things.

While these solutions are better than what I am submitting, current implementation is an instant crash with poor to no debugging and thus makes this project almost unusable in many situations. Thus I recommend we get this in and then look at creating something a little more robust.