### PR TITLE
Add support for defining open api responses without body and mediatype.

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Attributes/OpenApiResponseAttribute.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Attributes/OpenApiResponseAttribute.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net;
+
+namespace Aliencube.AzureFunctions.Extensions.OpenApi.Attributes
+{
+    /// <summary>
+    /// This represents the attribute entity for HTTP triggers to define response body payload.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class OpenApiResponseAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenApiResponseAttribute"/> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        public OpenApiResponseAttribute(HttpStatusCode statusCode)
+        {
+            this.StatusCode = statusCode;
+        }
+
+        /// <summary>
+        /// Gets the HTTP status code value.
+        /// </summary>
+        public virtual HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the summary.
+        /// </summary>
+        public virtual string Summary { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        public virtual string Description { get; set; }
+    }
+}

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Document.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Document.cs
@@ -123,7 +123,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
 
                 operation.Parameters = this._helper.GetOpenApiParameters(method, trigger);
                 operation.RequestBody = this._helper.GetOpenApiRequestBody(method);
-                operation.Responses = this._helper.GetOpenApiResponseBody(method);
+                operation.Responses = this._helper.GetOpenApiResponses(method);
 
                 operations[verb] = operation;
                 item.Operations = operations;

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -148,13 +148,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
         }
 
         /// <inheritdoc />
-        public OpenApiResponses GetOpenApiResponseBody(MethodInfo element, NamingStrategy namingStrategy = null)
+        public OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy = null)
         {
-            var responses = element.GetCustomAttributes<OpenApiResponseBodyAttribute>(inherit: false)
-                                   .ToDictionary(p => ((int)p.StatusCode).ToString(), p => p.ToOpenApiResponse(namingStrategy))
-                                   .ToOpenApiResponses();
+            var responsesWithBody = element.GetCustomAttributes<OpenApiResponseBodyAttribute>(inherit: false)
+                                   .Select(p => (StatusCode: p.StatusCode, Response: p.ToOpenApiResponse(namingStrategy)));
 
-            return responses;
+            var responses = element.GetCustomAttributes<OpenApiResponseAttribute>(inherit: false)
+                                   .Select(p => (StatusCode: p.StatusCode, Response: p.ToOpenApiResponse(namingStrategy)));
+
+            return responses.Concat(responsesWithBody).ToDictionary(x => ((int)x.StatusCode).ToString(), x => x.Response).ToOpenApiResponses();
         }
 
         /// <inheritdoc />

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiResponseAttributeExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiResponseAttributeExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+using Aliencube.AzureFunctions.Extensions.OpenApi.Attributes;
+
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json.Serialization;
+
+namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
+{
+    /// <summary>
+    /// This represents the extension entity for <see cref="OpenApiResponseBodyAttribute"/>.
+    /// </summary>
+    public static class OpenApiResponseAttributeExtensions
+    {
+        /// <summary>
+        /// Converts <see cref="OpenApiResponseBodyAttribute"/> to <see cref="OpenApiResponse"/>.
+        /// </summary>
+        /// <param name="attribute"><see cref="OpenApiResponseBodyAttribute"/> instance.</param>
+        /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
+        /// <returns><see cref="OpenApiResponse"/> instance.</returns>
+        public static OpenApiResponse ToOpenApiResponse(this OpenApiResponseAttribute attribute, NamingStrategy namingStrategy = null)
+        {
+            attribute.ThrowIfNullOrDefault();
+
+            var description = !string.IsNullOrWhiteSpace(attribute.Description) ? attribute.Description : "No description";
+            var response = new OpenApiResponse()
+            {
+                Description = description,
+            };
+
+            if (!string.IsNullOrWhiteSpace(attribute.Summary))
+            {
+                var summary = new OpenApiString(attribute.Summary);
+
+                response.Extensions.Add("x-ms-summary", summary);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocumentHelper.cs
@@ -88,7 +88,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Abstractions
         /// <param name="element"><see cref="MethodInfo"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <returns><see cref="OpenApiResponses"/> instance.</returns>
-        OpenApiResponses GetOpenApiResponseBody(MethodInfo element, NamingStrategy namingStrategy = null);
+        OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy = null);
 
         /// <summary>
         /// Gets the collection of <see cref="OpenApiSchema"/> instances.

--- a/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
@@ -53,6 +53,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
         [OpenApiResponseBody(statusCode: HttpStatusCode.InternalServerError, contentType: "application/json", bodyType: typeof(List<string>), Summary = "Sample response of a List")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.NotImplemented, contentType: "application/json", bodyType: typeof(Dictionary<string, int>), Summary = "Sample response of a Dictionary")]
         [OpenApiResponseBody(statusCode: HttpStatusCode.BadGateway, contentType: "application/json", bodyType: typeof(SampleGenericResponseModel<SampleResponseModel>), Summary = "Sample response of a Generic")]
+        [OpenApiResponse(statusCode: HttpStatusCode.NoContent)]
+        [OpenApiResponse(statusCode: HttpStatusCode.RequestTimeout, Description = "Sample response with only status code", Summary = "Sample summary")]
         public static async Task<IActionResult> GetSample(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "samples/{id:int}/categories/{category:regex(^[a-z]{{3,}}$)}")] HttpRequest req,
             int id,


### PR DESCRIPTION
Added new OpenApiResponseAttribute which doesn't require bodytype to be defined.