### PR TITLE
Support nested references in model properties, arrays and dictionaries

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -171,10 +171,10 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
                                 .Where(p => p != typeof(JObject))
                                 .Where(p => p != typeof(JToken))
                                 .Where(p => !typeof(Array).IsAssignableFrom(p))
-                                ;
-            var schemas = types.ToDictionary(p => p.IsGenericType ? p.GetOpenApiGenericRootName() : p.Name,
-                                             p => p.ToOpenApiSchema(namingStrategy)); // schemaGenerator.Generate(p)
+                                .ToList();
 
+            var schemas = new Dictionary<string, OpenApiSchema>();
+            types.ForEach(p => schemas.AddRange(p.ToOpenApiSchemas(namingStrategy)));
             return schemas;
         }
 

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/GenericExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/GenericExtensions.cs
@@ -49,5 +49,21 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
 
             return !items.Any();
         }
+
+        public static void AddRange<T, S>(this Dictionary<T, S> source, Dictionary<T, S> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("Collection is null");
+            }
+
+            foreach (var item in collection)
+            {
+                if (!source.ContainsKey(item.Key))
+                {
+                    source.Add(item.Key, item.Value);
+                }
+            }
+        }
     }
 }

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/OpenApiSchemaExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -27,34 +28,38 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
         /// <returns><see cref="OpenApiSchema"/> instance.</returns>
         /// <remarks>
         /// It runs recursively to build the entire object type. It only takes properties without <see cref="JsonIgnoreAttribute"/>.
-        /// </remarks>
+        /// </remarks>      
         public static OpenApiSchema ToOpenApiSchema(this Type type, NamingStrategy namingStrategy, OpenApiSchemaVisibilityAttribute attribute = null)
+        {
+            return ToOpenApiSchemas(type, namingStrategy, attribute, true).First().Value;
+        }
+        public static Dictionary<string, OpenApiSchema> ToOpenApiSchemas(this Type type, NamingStrategy namingStrategy, OpenApiSchemaVisibilityAttribute attribute = null, bool returnSingleSchema=false)
         {
             type.ThrowIfNullOrDefault();
 
             var schema = (OpenApiSchema)null;
+            var schemeName = type.IsGenericType ? type.GetOpenApiGenericRootName() : type.Name;
 
             if (type.IsJObjectType())
             {
-                schema = typeof(object).ToOpenApiSchema(namingStrategy);
+                schema = typeof(object).ToOpenApiSchemas(namingStrategy, null, true).First().Value;
 
-                return schema;
+                return new Dictionary<string, OpenApiSchema>() { { schemeName, schema } };
             }
 
             var unwrappedValueType = Nullable.GetUnderlyingType(type);
             if (!unwrappedValueType.IsNullOrDefault())
             {
-                schema = unwrappedValueType.ToOpenApiSchema(namingStrategy);
+                schema = unwrappedValueType.ToOpenApiSchemas(namingStrategy, null, true).First().Value;
                 schema.Nullable = true;
-
-                return schema;
+                return new Dictionary<string, OpenApiSchema>() { { schemeName, schema } };
             }
 
             schema = new OpenApiSchema()
-                         {
-                             Type = type.ToDataType(),
-                             Format = type.ToDataFormat()
-                         };
+            {
+                Type = type.ToDataType(),
+                Format = type.ToDataFormat()
+            };
 
             if (!attribute.IsNullOrDefault())
             {
@@ -81,29 +86,29 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
 
             if (type.IsSimpleType())
             {
-                return schema;
+                return new Dictionary<string, OpenApiSchema>() { { schemeName, schema } };
             }
 
             if (type.IsOpenApiDictionary())
             {
-                schema.AdditionalProperties = type.GetGenericArguments()[1].ToOpenApiSchema(namingStrategy);
+                schema.AdditionalProperties = type.GetGenericArguments()[1].ToOpenApiSchemas(namingStrategy, null, true).First().Value;
 
-                return schema;
+                return new Dictionary<string, OpenApiSchema>() { { schemeName, schema } };
             }
 
             if (type.IsOpenApiArray())
             {
                 schema.Type = "array";
-                schema.Items = (type.GetElementType() ?? type.GetGenericArguments()[0]).ToOpenApiSchema(namingStrategy);
+                schema.Items = (type.GetElementType() ?? type.GetGenericArguments()[0]).ToOpenApiSchemas(namingStrategy, null, true).First().Value;
 
-                return schema;
+                return new Dictionary<string, OpenApiSchema>() { { schemeName, schema } };
             }
 
             var allProperties = type.IsInterface
                                     ? new[] { type }.Concat(type.GetInterfaces()).SelectMany(i => i.GetProperties())
                                     : type.GetProperties();
             var properties = allProperties.Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>());
-
+            var retVal = new Dictionary<string, OpenApiSchema>();
             foreach (var property in properties)
             {
                 var visiblity = property.GetCustomAttribute<OpenApiSchemaVisibilityAttribute>(inherit: false);
@@ -112,16 +117,78 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                 var ts = property.DeclaringType.GetGenericArguments();
                 if (!ts.Any())
                 {
-                    schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchema(namingStrategy, visiblity);
+                    if (property.PropertyType.IsSimpleType() || returnSingleSchema)                      
+                    {
+                        schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchemas(namingStrategy, visiblity, true).First().Value;
 
+                    }
+                    else if (property.PropertyType.IsOpenApiDictionary())
+                    {
+                        var elementType = property.PropertyType.GetGenericArguments()[1];
+                        if (elementType.IsSimpleType() || elementType.IsOpenApiDictionary() || elementType.IsOpenApiArray())
+                            schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchemas(namingStrategy, visiblity, true).First().Value;
+                        else
+                        {
+                            var recur1 = elementType.ToOpenApiSchemas(namingStrategy, visiblity);
+                            retVal.AddRange(recur1);
+                            var elementReference = new OpenApiReference()
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = elementType.GetOpenApiReferenceId(false, false)
+                            };
+                            
+                            var dictionarySchema = new OpenApiSchema()
+                            {
+                                Type = "object",
+                                AdditionalProperties = new OpenApiSchema() { Reference = elementReference }
+                            };
+                            schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = dictionarySchema;
+                        }
+                    }
+                    else if (property.PropertyType.IsOpenApiArray())
+                    {
+                        var elementType = (property.PropertyType.GetElementType() ?? property.PropertyType.GetGenericArguments()[0]);
+                        if(elementType.IsSimpleType() || elementType.IsOpenApiDictionary() || elementType.IsOpenApiArray())
+                            schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchemas(namingStrategy, visiblity, true).First().Value;
+                        else
+                        {
+                            var elementReference = elementType.ToOpenApiSchemas(namingStrategy, visiblity);
+                            retVal.AddRange(elementReference);
+                            var reference1 = new OpenApiReference()
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = elementType.GetOpenApiReferenceId(false, false)
+                            };
+                            var arraySchema = new OpenApiSchema() {
+                                Type = "array",
+                                Items = new OpenApiSchema() {
+                                    Reference = reference1
+                                }
+                            };
+                            schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = arraySchema;
+                        }
+                        
+                    }
+                    else
+                    {
+                        var recur1 = property.PropertyType.ToOpenApiSchemas(namingStrategy, visiblity);
+                        retVal.AddRange(recur1);
+                        var reference1 = new OpenApiReference()
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = property.PropertyType.GetOpenApiReferenceId(false, false)
+                        };
+                        var schema1 = new OpenApiSchema() { Reference = reference1 };
+                        schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = schema1;                        
+                    }
                     continue;
                 }
 
                 var reference = new OpenApiReference()
-                                    {
-                                        Type = ReferenceType.Schema,
-                                        Id = property.PropertyType.GetOpenApiRootReferenceId()
-                                    };
+                {
+                    Type = ReferenceType.Schema,
+                    Id = property.PropertyType.GetOpenApiRootReferenceId()
+                };
                 var referenceSchema = new OpenApiSchema() { Reference = reference };
 
                 if (!ts.Contains(property.PropertyType))
@@ -130,10 +197,10 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                     {
                         reference.Id = property.PropertyType.GetOpenApiReferenceId(true, false);
                         var dictionarySchema = new OpenApiSchema()
-                                                   {
-                                                       Type = "object",
-                                                       AdditionalProperties = referenceSchema
-                                                   };
+                        {
+                            Type = "object",
+                            AdditionalProperties = referenceSchema
+                        };
                         schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = dictionarySchema;
 
                         continue;
@@ -143,24 +210,25 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
                     {
                         reference.Id = property.PropertyType.GetOpenApiReferenceId(false, true);
                         var arraySchema = new OpenApiSchema()
-                                              {
-                                                  Type = "array",
-                                                  Items = referenceSchema
-                                              };
+                        {
+                            Type = "array",
+                            Items = referenceSchema
+                        };
                         schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = arraySchema;
 
                         continue;
                     }
 
-                    schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchema(namingStrategy, visiblity);
+                    schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = property.PropertyType.ToOpenApiSchemas(namingStrategy, visiblity, true).First().Value;
 
                     continue;
                 }
 
                 schema.Properties[namingStrategy.GetPropertyName(property.Name, false)] = referenceSchema;
             }
-
-            return schema;
+          
+            retVal.Add(schemeName, schema);
+            return retVal;
         }
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -198,5 +198,48 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
 
             result.Properties.Count.Should().Be(4);
         }
+
+        [TestMethod]
+        public void Given_FakeModel_It_Should_Return_Result()
+        {
+            var type = typeof(FakeModel);
+            var strategy = new CamelCaseNamingStrategy();
+
+            var schemas = OpenApiSchemaExtensions.ToOpenApiSchemas(type, strategy);
+            schemas.Count.Should().Be(2);
+            var fmSchema = schemas[type.Name];
+            var fsmType = typeof(FakeSubModel);
+            var fsmSchema = schemas[fsmType.Name];
+            fmSchema.Type.Should().Be("object");
+            fmSchema.Properties["fakeProperty"].Type.Should().BeEquivalentTo("string");
+            fmSchema.Properties["subProperty"].Reference.Id.Should().BeEquivalentTo(fsmType.Name);
+
+            fsmSchema.Type.Should().Be("object");
+            fsmSchema.Properties["fakeSubModelProperty"].Type.Should().BeEquivalentTo("integer");
+
+
+        }
+
+        [TestMethod]
+        public void Given_FakeModelWithList_It_Should_Return_Result()
+        {
+            var type = typeof(FakeModelWithList);
+            var strategy = new CamelCaseNamingStrategy();
+
+            var schemas = OpenApiSchemaExtensions.ToOpenApiSchemas(type, strategy);
+            schemas.Count.Should().Be(2);
+            var fmSchema = schemas[type.Name];
+            var fsmType = typeof(FakeSubModel);
+            var fsmSchema = schemas[fsmType.Name];
+            fmSchema.Type.Should().Be("object");
+            fmSchema.Properties["parent"].Reference.Id.Should().BeEquivalentTo(fsmType.Name);
+            fmSchema.Properties["items"].Type.Should().BeEquivalentTo("array");
+            fmSchema.Properties["items"].Items.Reference.Id.Should().BeEquivalentTo(fsmType.Name);
+
+            fsmSchema.Type.Should().Be("object");
+            fsmSchema.Properties["fakeSubModelProperty"].Type.Should().BeEquivalentTo("integer");
+
+
+        }
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -241,5 +241,24 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
 
 
         }
+        [TestMethod]
+        public void Given_FakeModelWithCircularRef_It_Should_Return_Result()
+        {
+            var type = typeof(FakeModelWithCircularRef);
+            var strategy = new CamelCaseNamingStrategy();
+
+            var schemas = OpenApiSchemaExtensions.ToOpenApiSchemas(type, strategy);
+            schemas.Count.Should().Be(2);
+            var fmSchema = schemas[type.Name];
+            var fsmType = typeof(FakeModelWithCircularRefSub);
+            var fsmSchema = schemas[fsmType.Name];
+            fmSchema.Type.Should().Be("object");
+            fmSchema.Properties["subProperty"].Reference.Id.Should().BeEquivalentTo(fsmType.Name);
+
+            fsmSchema.Type.Should().Be("object");
+            fsmSchema.Properties["circle"].Reference.Id.Should().BeEquivalentTo(type.Name);
+
+
+        }
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -206,16 +206,24 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Tests.Extensions
             var strategy = new CamelCaseNamingStrategy();
 
             var schemas = OpenApiSchemaExtensions.ToOpenApiSchemas(type, strategy);
-            schemas.Count.Should().Be(2);
+            schemas.Count.Should().Be(3);
             var fmSchema = schemas[type.Name];
             var fsmType = typeof(FakeSubModel);
             var fsmSchema = schemas[fsmType.Name];
+            var feType = typeof(FakeEnum);
+            var feSchema = schemas[feType.Name];
             fmSchema.Type.Should().Be("object");
             fmSchema.Properties["fakeProperty"].Type.Should().BeEquivalentTo("string");
+            fmSchema.Properties["nullableInt"].Type.Should().BeEquivalentTo("integer");
+            fmSchema.Properties["nullableInt"].Nullable.Should().BeTrue();
             fmSchema.Properties["subProperty"].Reference.Id.Should().BeEquivalentTo(fsmType.Name);
+            fmSchema.Properties["enumProperty"].Reference.Id.Should().BeEquivalentTo(feType.Name);
 
             fsmSchema.Type.Should().Be("object");
             fsmSchema.Properties["fakeSubModelProperty"].Type.Should().BeEquivalentTo("integer");
+
+            feSchema.Type.Should().Be("integer");
+            feSchema.Enum.Count.Should().Be(2);
 
 
         }

--- a/test/Aliencube.AzureFunctions.FunctionAppV2.Tests/OpenApiHttpTriggerTests.cs
+++ b/test/Aliencube.AzureFunctions.FunctionAppV2.Tests/OpenApiHttpTriggerTests.cs
@@ -73,7 +73,10 @@ namespace Aliencube.AzureFunctions.FunctionAppV2.Tests
 
             enumPropToken.Should().NotBeNull();
 
-            var enumValues = enumPropToken["enum"];
+            var enumRef = enumPropToken["$ref"];
+            enumRef.Should().NotBeNull();
+            var enumValues = result.SelectToken(
+                $"$..{typeof(StringEnum).Name}")["enum"];
             enumValues.Should().NotBeNull();
 
             enumValues.Children().Select(t => t.Value<string>()).Should()
@@ -97,9 +100,11 @@ namespace Aliencube.AzureFunctions.FunctionAppV2.Tests
 
             enumPropToken.Should().NotBeNull();
 
-            var enumValues = enumPropToken["enum"];
+            var enumRef = enumPropToken["$ref"];
+            enumRef.Should().NotBeNull();
+            var enumValues = result.SelectToken(
+                $"$..{typeof(NumericEnum).Name}")["enum"];
             enumValues.Should().NotBeNull();
-
             enumValues.Children().Select(t => t.Value<string>()).Should()
                 .BeEquivalentTo(Enum.GetValues(typeof(NumericEnum)));
         }

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModel.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModel.cs
@@ -9,6 +9,9 @@
         /// Gets or sets the value.
         /// </summary>
         public string FakeProperty { get; set; }
+        public int? NullableInt { get; set; }
         public FakeSubModel SubProperty { get; set; }
+        public FakeEnum EnumProperty { get; set; }
+
     }
 }

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithCircularRef.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithCircularRef.cs
@@ -1,0 +1,14 @@
+﻿namespace Aliencube.AzureFunctions.Tests.Fakes
+{
+    /// <summary>
+    /// This represents the fake model entity.
+    /// </summary>
+    public class FakeModelWithCircularRef
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public string FakeProperty { get; set; }
+        public FakeModelWithCircularRefSub SubProperty { get; set; }
+    }
+}

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithCircularRefSub.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithCircularRefSub.cs
@@ -1,0 +1,13 @@
+﻿namespace Aliencube.AzureFunctions.Tests.Fakes
+{
+    /// <summary>
+    /// This represents the fake model entity.
+    /// </summary>
+    public class FakeModelWithCircularRefSub
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public FakeModelWithCircularRef Circle { get; set; }
+    }
+}

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithList.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/FakeModelWithList.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Aliencube.AzureFunctions.Tests.Fakes
+{
+    /// <summary>
+    /// This represents the fake model entity.
+    /// </summary>
+    public class FakeModelWithList
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public FakeSubModel Parent { get; set; }
+        public List<FakeSubModel> Items { get; set; }
+    }
+}

--- a/test/Aliencube.AzureFunctions.Tests.Fakes/FakeSubModel.cs
+++ b/test/Aliencube.AzureFunctions.Tests.Fakes/FakeSubModel.cs
@@ -3,12 +3,11 @@
     /// <summary>
     /// This represents the fake model entity.
     /// </summary>
-    public class FakeModel
+    public class FakeSubModel
     {
         /// <summary>
         /// Gets or sets the value.
         /// </summary>
-        public string FakeProperty { get; set; }
-        public FakeSubModel SubProperty { get; set; }
+        public int FakeSubModelProperty { get; set; }
     }
 }


### PR DESCRIPTION
Support for nested references in model properties. For example:
````
//Model class:
public class SampleResponseModel{
    public SubSampleResponseModel Sub { get; set; }
}
//JSON document:
"SubSampleResponseModel": {
  "type": "object",
  "properties": {
    "Key": {
    "type": "string"
  },
  "Value": {
    "format": "int32",
    "type": "integer"
  }
}
},
"SampleResponseModel": {
  "type": "object",
  "properties": {
    "Sub": {
      "$ref": "#/definitions/SubSampleResponseModel" //<-- instead of inlining the object 
    }
  }
}
````
Also added unit tests, and a fix for circular references (thanks @madninjaskillz #59 )