### PR TITLE
Fixes OpenApiResponseWithoutBodyAttribute documentation

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -269,7 +269,7 @@ This decorator implements the [Response object](https://github.com/OAI/OpenAPI-S
 
 ```csharp
 [FunctionName(nameof(PostSample))]
-[OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(SampleResponseModel))]
+[OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK)]
 ...
 public static async Task<IActionResult> PostSample(
     [HttpTrigger(AuthorizationLevel.Function, "post", Route = "samples")] HttpRequest req,


### PR DESCRIPTION
This pull request updates the documentation for the `OpenApiResponseWithoutBodyAttribute` decorator as referenced in Issue #98 .