### PR TITLE
Fixes JsonProperty with no PropertyName value and adds tests

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Extensions/PropertyInfoExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Extensions/PropertyInfoExtensions.cs
@@ -37,7 +37,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Extensions
 
             if (element.HasJsonPropertyAttribute())
             {
-                var name = element.GetCustomAttribute<JsonPropertyAttribute>().PropertyName ?? element.Name;
+                var name = element.GetCustomAttribute<JsonPropertyAttribute>().PropertyName ?? namingStrategy.GetPropertyName(element.Name, hasSpecifiedName: false);
 
                 return name;
 

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Extensions/PropertyInfoExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Extensions/PropertyInfoExtensions.cs
@@ -37,7 +37,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Extensions
 
             if (element.HasJsonPropertyAttribute())
             {
-                var name = element.GetCustomAttribute<JsonPropertyAttribute>().PropertyName;
+                var name = element.GetCustomAttribute<JsonPropertyAttribute>().PropertyName ?? element.Name;
 
                 return name;
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
@@ -19,6 +19,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes
         [JsonProperty("anotherFakeProperty", Required = Required.Always)]
         public string FakeProperty2 { get; set; }
 
+        [JsonProperty(Required = Required.Default)]
+        public string FakePropertyNoPropertyValue { get; set; }
+
+        [JsonProperty]
+        public string FakePropertyNoAnnotation { get; set; }
+
         /// <summary>
         /// Gets or sets the nullable int value.
         /// </summary>

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
@@ -40,5 +40,31 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Extensions
 
             result.Should().Be(jsonPropertyName);
         }
+
+        [TestMethod]
+        public void Given_Property_When_GetJsonPropertyName_IsEmpty_Then_It_Should_Return_ElementName()
+        {
+            var name = "FakePropertyNoPropertyValue";
+            var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            var namingStrategy = new DefaultNamingStrategy();
+
+            var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
+
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Be(name);
+        }
+
+        [TestMethod]
+        public void Given_Property_When_DefaultJsonProperyAnnotation_Invoked_Then_It_Should_Return_ElementName()
+        {
+            var name = "FakePropertyNoAnnotation";
+            var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            var namingStrategy = new DefaultNamingStrategy();
+
+            var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
+
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Be(name);
+        }
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
@@ -71,26 +71,28 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Extensions
         public void Given_Property_When_GetJsonPropertyName_IsEmpty_WithCamelCaseNaming_Then_It_Should_Return_ElementName()
         {
             var name = "FakePropertyNoPropertyValue";
+            var camelCaseName = "fakePropertyNoPropertyValue";
             var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
             var namingStrategy = new CamelCaseNamingStrategy();
 
             var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
 
             result.Should().NotBeNullOrEmpty();
-            result.Should().Be(name);
+            result.Should().Be(camelCaseName);
         }
 
         [TestMethod]
         public void Given_Property_When_DefaultJsonProperyAnnotation_Invoked_WithCamelCaseNaming_Then_It_Should_Return_ElementName()
         {
             var name = "FakePropertyNoAnnotation";
+            var camelCaseName = "fakePropertyNoAnnotation";
             var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
             var namingStrategy = new CamelCaseNamingStrategy();
 
             var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
 
             result.Should().NotBeNullOrEmpty();
-            result.Should().Be(name);
+            result.Should().Be(camelCaseName);
         }
     }
 }

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Extensions/PropertyInfoExtensionsTests.cs
@@ -66,5 +66,31 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Extensions
             result.Should().NotBeNullOrEmpty();
             result.Should().Be(name);
         }
+
+        [TestMethod]
+        public void Given_Property_When_GetJsonPropertyName_IsEmpty_WithCamelCaseNaming_Then_It_Should_Return_ElementName()
+        {
+            var name = "FakePropertyNoPropertyValue";
+            var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            var namingStrategy = new CamelCaseNamingStrategy();
+
+            var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
+
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Be(name);
+        }
+
+        [TestMethod]
+        public void Given_Property_When_DefaultJsonProperyAnnotation_Invoked_WithCamelCaseNaming_Then_It_Should_Return_ElementName()
+        {
+            var name = "FakePropertyNoAnnotation";
+            var property = typeof(FakeModel).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            var namingStrategy = new CamelCaseNamingStrategy();
+
+            var result = PropertyInfoExtensions.GetJsonPropertyName(property, namingStrategy);
+
+            result.Should().NotBeNullOrEmpty();
+            result.Should().Be(name);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes Issue #101 

In `PropertyInfoExtensions.cs` when the custom attribute does not have the PropertyName field populated, it currently returns `null` causing a thrown error further in the stack. This PR adds a fallback value to the `element.Name` property if the `PropertyName` is not populated. This adds support for attributes such as `[JsonProperty(Required.Default)]` and `[JsonProperty]`. I added two test cases to prove the functionality and all existing tests continue to pass.