### PR TITLE
Allow customization of VisitorCollection IVisitors; Add a UriTypeVisitor

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/Program.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/Program.cs
@@ -84,7 +84,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.CLI
             var filter = new RouteConstraintFilter();
             var acceptor = new OpenApiSchemaAcceptor();
             var namingStrategy = new CamelCaseNamingStrategy();
-            var collection = this.GetVisitorCollection();
+            var collection = VisitorCollection.CreateInstance();
             var helper = new DocumentHelper(filter, acceptor);
             var document = new Document(helper);
 
@@ -135,18 +135,6 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.CLI
             }
 
             File.WriteAllText($"{outputpath}{directorySeparator}swagger.{format.ToDisplayName()}", swagger, Encoding.UTF8);
-        }
-
-        private VisitorCollection GetVisitorCollection()
-        {
-            var visitors = typeof(IVisitor).Assembly
-                                           .GetTypes()
-                                           .Where(p => p.Name.EndsWith("Visitor") && p.IsClass && !p.IsAbstract)
-                                           .Select(p => (IVisitor)Activator.CreateInstance(p))
-                                           .ToList();
-            var collection = new VisitorCollection(visitors);
-
-            return collection;
         }
     }
 }

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/BooleanTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/BooleanTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class BooleanTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public BooleanTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Boolean);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DateTimeObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DateTimeObjectTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class DateTimeObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public DateTimeObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(DateTime);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DateTimeOffsetObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DateTimeOffsetObjectTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class DateTimeOffsetObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public DateTimeOffsetObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(DateTimeOffset);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DecimalTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DecimalTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class DecimalTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public DecimalTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Decimal);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DictionaryObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DictionaryObjectTypeVisitor.cs
@@ -17,6 +17,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class DictionaryObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public DictionaryObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.IsOpenApiDictionary();
@@ -55,8 +61,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                 Schemas = schemas,
             };
 
-            var collection = VisitorCollection.CreateInstance();
-            subAcceptor.Accept(collection, namingStrategy);
+            subAcceptor.Accept(this.VisitorCollection, namingStrategy);
 
             var properties = subAcceptor.Schemas.First().Value;
 
@@ -120,8 +125,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
 
             // Gets the schema for the underlying type.
             var underlyingType = type.GetGenericArguments()[1];
-            var collection = VisitorCollection.CreateInstance();
-            var properties = collection.PayloadVisit(underlyingType, namingStrategy);
+            var properties = this.VisitorCollection.PayloadVisit(underlyingType, namingStrategy);
 
             // Adds the reference to the schema for the underlying type.
             var reference = new OpenApiReference()

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DoubleTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/DoubleTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class DoubleTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public DoubleTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Double);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/GuidObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/GuidObjectTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class GuidObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public GuidObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(Guid);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int16EnumTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int16EnumTypeVisitor.cs
@@ -20,6 +20,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int16EnumTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int16EnumTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int16) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int16TypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int16TypeVisitor.cs
@@ -16,6 +16,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int16TypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int16TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int16) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int32EnumTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int32EnumTypeVisitor.cs
@@ -20,6 +20,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int32EnumTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int32EnumTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int32) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int32TypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int32TypeVisitor.cs
@@ -16,6 +16,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int32TypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int32TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int32) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int64EnumTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int64EnumTypeVisitor.cs
@@ -20,6 +20,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int64EnumTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int64EnumTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int64) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int64TypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/Int64TypeVisitor.cs
@@ -16,6 +16,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class Int64TypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public Int64TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Int64) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/JObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/JObjectTypeVisitor.cs
@@ -17,6 +17,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class JObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public JObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.IsJObjectType();

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
@@ -17,6 +17,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class ListObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public ListObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.IsOpenApiArray();
@@ -55,8 +61,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                 Schemas = schemas,
             };
 
-            var collection = VisitorCollection.CreateInstance();
-            subAcceptor.Accept(collection, namingStrategy);
+            subAcceptor.Accept(this.VisitorCollection, namingStrategy);
 
             var items = subAcceptor.Schemas.First().Value;
 
@@ -113,8 +118,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
             var schema = this.ParameterVisit(dataType: "array", dataFormat: null);
 
             var underlyingType = type.GetElementType() ?? type.GetGenericArguments()[0];
-            var collection = VisitorCollection.CreateInstance();
-            var items = collection.ParameterVisit(underlyingType, namingStrategy);
+            var items = this.VisitorCollection.ParameterVisit(underlyingType, namingStrategy);
 
             schema.Items = items;
 
@@ -136,8 +140,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
 
             // Gets the schema for the underlying type.
             var underlyingType = type.GetElementType() ?? type.GetGenericArguments()[0];
-            var collection = VisitorCollection.CreateInstance();
-            var items = collection.PayloadVisit(underlyingType, namingStrategy);
+            var items = this.VisitorCollection.PayloadVisit(underlyingType, namingStrategy);
 
             // Adds the reference to the schema for the underlying type.
             var reference = new OpenApiReference()

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/NullableObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/NullableObjectTypeVisitor.cs
@@ -19,6 +19,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class NullableObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public NullableObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.IsOpenApiNullable();
@@ -50,8 +56,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                 Schemas = schemas,
             };
 
-            var collection = VisitorCollection.CreateInstance();
-            subAcceptor.Accept(collection, namingStrategy);
+            subAcceptor.Accept(this.VisitorCollection, namingStrategy);
 
             // Adds the schema for the underlying type.
             var name = subAcceptor.Schemas.First().Key;
@@ -85,8 +90,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
         {
             type.IsOpenApiNullable(out var underlyingType);
-            var collection = VisitorCollection.CreateInstance();
-            var schema = collection.ParameterVisit(underlyingType, namingStrategy);
+            var schema = this.VisitorCollection.ParameterVisit(underlyingType, namingStrategy);
 
             schema.Nullable = true;
 
@@ -105,8 +109,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
         {
             type.IsOpenApiNullable(out var underlyingType);
-            var collection = VisitorCollection.CreateInstance();
-            var schema = collection.PayloadVisit(underlyingType, namingStrategy);
+            var schema = this.VisitorCollection.PayloadVisit(underlyingType, namingStrategy);
 
             schema.Nullable = true;
 

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -45,6 +45,14 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            else if (type.IsOpenApiArray())
+            {
+                isVisitable = false;
+            }
+            else if (type.IsOpenApiDictionary())
+            {
+                isVisitable = false;
+            }
             else if (type.IsOpenApiNullable())
             {
                 isVisitable = false;

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -28,31 +28,36 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object);
+
             if (type == typeof(Guid))
             {
                 isVisitable = false;
             }
-            if (type == typeof(DateTime))
+            else if (type == typeof(DateTime))
             {
                 isVisitable = false;
             }
-            if (type == typeof(DateTimeOffset))
+            else if (type == typeof(DateTimeOffset))
             {
                 isVisitable = false;
             }
-            if (type.IsOpenApiNullable())
+            else if (type == typeof(Uri))
             {
                 isVisitable = false;
             }
-            if (type.IsUnflaggedEnumType())
+            else if (type.IsOpenApiNullable())
             {
                 isVisitable = false;
             }
-            if (type.IsJObjectType())
+            else if (type.IsUnflaggedEnumType())
             {
                 isVisitable = false;
             }
-            if (type.HasRecursiveProperty())
+            else if (type.IsJObjectType())
+            {
+                isVisitable = false;
+            }
+            else if (type.HasRecursiveProperty())
             {
                 isVisitable = false;
             }

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -19,6 +19,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class ObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public ObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object);
@@ -145,8 +151,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                 Schemas = schemas,
             };
 
-            var collection = VisitorCollection.CreateInstance();
-            subAcceptor.Accept(collection, namingStrategy);
+            subAcceptor.Accept(this.VisitorCollection, namingStrategy);
 
             // Add required properties to schema.
             var jsonPropertyAttributes = properties.Where(p => !p.Value.GetCustomAttribute<JsonPropertyAttribute>(inherit: false).IsNullOrDefault())

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -19,6 +19,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class RecursiveObjectTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public RecursiveObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.HasRecursiveProperty();
@@ -163,8 +169,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                 Schemas = schemas,
             };
 
-            var collection = VisitorCollection.CreateInstance();
-            subAcceptor.Accept(collection, namingStrategy);
+            subAcceptor.Accept(this.VisitorCollection, namingStrategy);
 
             // Add required properties to schema.
             var jsonPropertyAttributes = properties.Where(p => !p.Value.GetCustomAttribute<JsonPropertyAttribute>(inherit: false).IsNullOrDefault())

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/SingleTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/SingleTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class SingleTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public SingleTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Single);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
@@ -20,6 +20,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class StringEnumTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public StringEnumTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = (this.IsVisitable(type, TypeCode.Int16) || this.IsVisitable(type, TypeCode.Int32) || this.IsVisitable(type, TypeCode.Int64)) &&

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/StringTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/StringTypeVisitor.cs
@@ -15,6 +15,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public class StringTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
+        public StringTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.String);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
@@ -19,9 +19,23 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
     public abstract class TypeVisitor : IVisitor
     {
         /// <summary>
+        /// Constructor required for <see cref="VisitorCollection"/>
+        /// </summary>
+        /// <param name="visitorCollection"><see cref="VisitorCollection"/></param>
+        public TypeVisitor(VisitorCollection visitorCollection)
+        {
+            this.VisitorCollection = visitorCollection;
+        }
+
+        /// <summary>
         /// Gets the <see cref="Type"/> object.
         /// </summary>
         protected Type Type { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="VisitorCollection"/>.
+        /// </summary>
+        protected VisitorCollection VisitorCollection { get; }
 
         /// <inheritdoc />
         public virtual bool IsVisitable(Type type)

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/UriTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/UriTypeVisitor.cs
@@ -1,21 +1,18 @@
 using System;
 using System.Collections.Generic;
-
 using Aliencube.AzureFunctions.Extensions.OpenApi.Core.Abstractions;
-
 using Microsoft.OpenApi.Models;
-
 using Newtonsoft.Json.Serialization;
 
 namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
 {
     /// <summary>
-    /// This represents the type visitor for <see cref="DateTime"/>.
+    /// This represents the type visitor for <see cref="Uri"/>.
     /// </summary>
-    public class DateTimeTypeVisitor : TypeVisitor
+    public class UriTypeVisitor : TypeVisitor
     {
         /// <inheritdoc />
-        public DateTimeTypeVisitor(VisitorCollection visitorCollection)
+        public UriTypeVisitor(VisitorCollection visitorCollection)
             : base(visitorCollection)
         {
         }
@@ -23,15 +20,13 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
-            var isVisitable = this.IsVisitable(type, TypeCode.DateTime);
-
-            return isVisitable;
+            return type.IsAssignableFrom(typeof(Uri));
         }
 
         /// <inheritdoc />
         public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
         {
-            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "date-time", attributes: attributes);
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "uri", attributes: attributes);
         }
 
         /// <inheritdoc />
@@ -45,7 +40,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
         {
-            return this.ParameterVisit(dataType: "string", dataFormat: "date-time");
+            return this.ParameterVisit(dataType: "string", dataFormat: "uri");
         }
 
         /// <inheritdoc />
@@ -59,7 +54,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
         {
-            return this.PayloadVisit(dataType: "string", dataFormat: "date-time");
+            return this.PayloadVisit(dataType: "string", dataFormat: "uri");
         }
     }
 }

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
@@ -36,21 +36,22 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
         /// <summary>
         /// Gets the list of <see cref="IVisitor"/> instances.
         /// </summary>
-        public List<IVisitor> Visitors { get; }
+        public List<IVisitor> Visitors { get; private set; }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="VisitorCollection"/> class.
+        /// Creates a new instance of the <see cref="VisitorCollection"/> class by scanning the current assembly for <see cref="IVisitor"/>.
         /// </summary>
+        /// <remarks>
+        /// There is an expectation that the <see cref="IVisitor"/> implementation has a constructor that takes a <see cref="VisitorCollection"/> as the only parameter.
+        /// </remarks>
         /// <returns>Returns the <see cref="VisitorCollection"/> instance.</returns>
         public static VisitorCollection CreateInstance()
         {
-            var visitors = typeof(IVisitor).Assembly
+            var collection = new VisitorCollection();
+            collection.Visitors = typeof(IVisitor).Assembly
                                            .GetTypes()
                                            .Where(p => p.Name.EndsWith("Visitor") && p.IsClass && !p.IsAbstract)
-                                           .Select(p => (IVisitor)Activator.CreateInstance(p))
-                                           .ToList();
-            var collection = new VisitorCollection(visitors);
-
+                                           .Select(p => (IVisitor)Activator.CreateInstance(p, collection)).ToList(); // NOTE: there is no direct enforcement on the constructor arguments of the visitors
             return collection;
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeTypeVisitor.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeTypeVisitor.cs
@@ -6,6 +6,11 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes
 {
     public class FakeTypeVisitor : TypeVisitor
     {
+        public FakeTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
         public bool IsTypeReferential(Type type)
         {
             return this.IsReferential(type);

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class BooleanTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new BooleanTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new BooleanTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class DateTimeOffsetObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new DateTimeOffsetObjectTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new DateTimeOffsetObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class DateTimeTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new DateTimeTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new DateTimeTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class DecimalTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new DecimalTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new DecimalTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
@@ -22,13 +22,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class DictionaryObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new DictionaryObjectTypeVisitor();
+            this._visitorCollection = VisitorCollection.CreateInstance();
+            this._visitor = new DictionaryObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class GuidObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new GuidObjectTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new GuidObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int16EnumTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int16EnumTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int16EnumTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int16TypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int16TypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int16TypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int32EnumTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int32EnumTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int32EnumTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int32TypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int32TypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int32TypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int64EnumTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int64EnumTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int64EnumTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class Int64TypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new Int64TypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new Int64TypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class JObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new JObjectTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new JObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
@@ -22,13 +22,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class ListObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new ListObjectTypeVisitor();
+            this._visitorCollection = VisitorCollection.CreateInstance();
+            this._visitor = new ListObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class NullableObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new NullableObjectTypeVisitor();
+            this._visitorCollection = VisitorCollection.CreateInstance();
+            this._visitor = new NullableObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -46,6 +46,8 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(FakeModel), true)]
         [DataRow(typeof(int), false)]
         [DataRow(typeof(Uri), false)]
+        [DataRow(typeof(IEnumerable<object>), false)]
+        [DataRow(typeof(IDictionary<string, object>), false)]
         public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsVisitable(type);
@@ -57,6 +59,8 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(FakeModel), false)]
         [DataRow(typeof(int), false)]
         [DataRow(typeof(Uri), false)]
+        [DataRow(typeof(IEnumerable<object>), false)]
+        [DataRow(typeof(IDictionary<string, object>), false)]
         public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsParameterVisitable(type);
@@ -68,6 +72,8 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(FakeModel), true)]
         [DataRow(typeof(int), false)]
         [DataRow(typeof(Uri), false)]
+        [DataRow(typeof(IEnumerable<object>), false)]
+        [DataRow(typeof(IDictionary<string, object>), false)]
         public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsPayloadVisitable(type);

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -45,6 +45,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataTestMethod]
         [DataRow(typeof(FakeModel), true)]
         [DataRow(typeof(int), false)]
+        [DataRow(typeof(Uri), false)]
         public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsVisitable(type);
@@ -55,6 +56,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataTestMethod]
         [DataRow(typeof(FakeModel), false)]
         [DataRow(typeof(int), false)]
+        [DataRow(typeof(Uri), false)]
         public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsParameterVisitable(type);
@@ -65,6 +67,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         [DataTestMethod]
         [DataRow(typeof(FakeModel), true)]
         [DataRow(typeof(int), false)]
+        [DataRow(typeof(Uri), false)]
         public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsPayloadVisitable(type);

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class ObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new ObjectTypeVisitor();
+            this._visitorCollection = VisitorCollection.CreateInstance();
+            this._visitor = new ObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class RecursiveObjectTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new RecursiveObjectTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new RecursiveObjectTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class SingleTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new SingleTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new SingleTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
@@ -21,13 +21,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class StringEnumTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new StringEnumTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new StringEnumTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
@@ -19,13 +19,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class StringTypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new StringTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new StringTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/TypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/TypeVisitorTests.cs
@@ -2,7 +2,7 @@ using System;
 
 using Aliencube.AzureFunctions.Extensions.OpenApi.Core.Abstractions;
 using Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes;
-
+using Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors;
 using FluentAssertions;
 
 using Microsoft.OpenApi.Models;
@@ -15,13 +15,15 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
     [TestClass]
     public class TypeVisitorTests
     {
+        private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
         private NamingStrategy _strategy;
 
         [TestInitialize]
         public void Init()
         {
-            this._visitor = new FakeTypeVisitor();
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new FakeTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json.Serialization;
 namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
 {
     [TestClass]
-    public class DoubleTypeVisitorTests
+    public class UriTypeVisitorTests
     {
         private VisitorCollection _visitorCollection;
         private IVisitor _visitor;
@@ -27,12 +27,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         public void Init()
         {
             this._visitorCollection = new VisitorCollection();
-            this._visitor = new DoubleTypeVisitor(this._visitorCollection);
+            this._visitor = new UriTypeVisitor(this._visitorCollection);
             this._strategy = new CamelCaseNamingStrategy();
         }
 
         [DataTestMethod]
-        [DataRow(typeof(double), false)]
+        [DataRow(typeof(string), false)]
         public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsNavigatable(type);
@@ -41,7 +41,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow(typeof(double), true)]
+        [DataRow(typeof(Uri), true)]
         [DataRow(typeof(int), false)]
         public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
@@ -51,7 +51,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow(typeof(double), true)]
+        [DataRow(typeof(Uri), true)]
         [DataRow(typeof(int), false)]
         public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
@@ -61,7 +61,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow(typeof(double), true)]
+        [DataRow(typeof(Uri), true)]
         [DataRow(typeof(int), false)]
         public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
@@ -71,12 +71,12 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow("number", "double")]
+        [DataRow("string", "uri")]
         public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
         {
             var name = "hello";
             var acceptor = new OpenApiSchemaAcceptor();
-            var type = new KeyValuePair<string, Type>(name, typeof(double));
+            var type = new KeyValuePair<string, Type>(name, typeof(Uri));
 
             this._visitor.Visit(acceptor, type, this._strategy);
 
@@ -93,7 +93,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         {
             var name = "hello";
             var acceptor = new OpenApiSchemaAcceptor();
-            var type = new KeyValuePair<string, Type>(name, typeof(double));
+            var type = new KeyValuePair<string, Type>(name, typeof(Uri));
             var attribute = new OpenApiSchemaVisibilityAttribute(visibility);
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
@@ -104,20 +104,20 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow("number", "double")]
+        [DataRow("string", "uri")]
         public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
         {
-            var result = this._visitor.ParameterVisit(typeof(double), this._strategy);
+            var result = this._visitor.ParameterVisit(typeof(Uri), this._strategy);
 
             result.Type.Should().Be(dataType);
             result.Format.Should().Be(dataFormat);
         }
 
         [DataTestMethod]
-        [DataRow("number", "double")]
+        [DataRow("string", "uri")]
         public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
         {
-            var result = this._visitor.PayloadVisit(typeof(double), this._strategy);
+            var result = this._visitor.PayloadVisit(typeof(Uri), this._strategy);
 
             result.Type.Should().Be(dataType);
             result.Format.Should().Be(dataFormat);


### PR DESCRIPTION
The static references to the VisitorCollection.CreateInstance prohibited the ability to customize the collection of IVisitor implementations. This pull request adds a constructor that takes the current collection so, you can, in your start up context of the function, amend the set of available visitors (for example, if you want to override the behavior of the string enum visitor or have a type that requires special handling).

Also added a UriTypeVisitor for models that present a Uri as "string"/"uri" in the OpenAPI spec.