### PR TITLE
fix for having multiple properties of same type on response body

### DIFF
--- a/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
+++ b/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
@@ -35,7 +35,14 @@ namespace Aliencube.AzureFunctions.FunctionApp.Models
         /// </summary>
         public List<Tag> Tags { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="Tag"/> value.
+        /// </summary>
         public Tag Tag1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Tag"/> value.
+        /// </summary>
         public Tag Tag2 { get; set; }
 
         /// <summary>

--- a/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
+++ b/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
@@ -36,12 +36,12 @@ namespace Aliencube.AzureFunctions.FunctionApp.Models
         public List<Tag> Tags { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Tag"/> value.
+        /// Gets or sets the Tag1 <see cref="Tag"/> value.
         /// </summary>
         public Tag Tag1 { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Tag"/> value.
+        /// Gets or sets the Tag2 <see cref="Tag"/> value.
         /// </summary>
         public Tag Tag2 { get; set; }
 

--- a/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
+++ b/samples/Aliencube.AzureFunctions.FunctionApp.Models/Pet.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-
 using Newtonsoft.Json;
 
 namespace Aliencube.AzureFunctions.FunctionApp.Models
@@ -35,6 +34,9 @@ namespace Aliencube.AzureFunctions.FunctionApp.Models
         /// Gets or sets the list of tags.
         /// </summary>
         public List<Tag> Tags { get; set; }
+
+        public Tag Tag1 { get; set; }
+        public Tag Tag2 { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="PetStatus"/> value.

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -197,6 +197,8 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Visitors
                                                           p.Value.Format.IsNullOrWhiteSpace() &&
                                                           p.Value.Items.IsNullOrDefault() &&
                                                           p.Value.AdditionalProperties.IsNullOrDefault())
+                                              .GroupBy(p=>p.Value.Title)
+                                              .Select(g=>g.First())
                                               .ToDictionary(p => p.Value.Title, p => p.Value);
 
             foreach (var schema in schemasToBeAdded.Where(p => p.Key != "jObject" && p.Key != "jToken"))

--- a/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
+++ b/test/Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
@@ -36,6 +36,11 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Core.Tests.Fakes
         public FakeSubModel SubProperty { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="FakeSubModel"/> instance.
+        /// </summary>
+        public FakeSubModel SubProperty2 { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="FakeStringEnum"/> value.
         /// </summary>
         public FakeStringEnum EnumProperty { get; set; }


### PR DESCRIPTION
Adding multiple properties of the same _complex_ type as response body fails with exception similar to this: 

`An item with the same key has already been added. Key: fakeSubModel`

This PR add this to the tests and V3IOC sample, as well as implementing a fix for the problem in `ObjectTypeVisitor.cs`