### PR TITLE
Throw exception in case of error getting ProjectInfo

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/Program.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/Program.cs
@@ -66,9 +66,9 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.CLI
             {
                 pi = new ProjectInfo(project, configuration, target);
             }
-            catch
+            catch (Exception ex)
             {
-                return;
+                throw ex;
             }
 #if NET461
             var requestUri = new Uri("http://localhost:7071");


### PR DESCRIPTION
At least throw exception if invalid commandline given.  Could be improved.  Helps with #122 