### PR TITLE
Handle explicit .csproj in --project path

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/ProjectInfo.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi.CLI/ProjectInfo.cs
@@ -219,6 +219,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.CLI
 
                 this._projectPath = csproj.DirectoryName.TrimEnd(directorySeparator);
                 this._filename = csproj.Name;
+                return;
             }
 
             var di = new DirectoryInfo(fqpath);


### PR DESCRIPTION
Don't double append .csproj to this._filename. Fixes #125 