### PR TITLE
Allow any version of .net Framework to be used for V1 Azure Functions

### DIFF
--- a/templates/OpenApiEndpints/OpenApiHttpTriggerV1.cs
+++ b/templates/OpenApiEndpints/OpenApiHttpTriggerV1.cs
@@ -1,4 +1,3 @@
-#if NET461
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -323,4 +322,3 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
         }
     }
 }
-#endif


### PR DESCRIPTION
Apply fix suggested in #121 to allow .net Frameworks other than 4.6.1 to be used in V1 functions, e.g. 4.6.2.